### PR TITLE
Javi Carnero proposed solution

### DIFF
--- a/javier-carnero/exercise/.gitignore
+++ b/javier-carnero/exercise/.gitignore
@@ -1,0 +1,2 @@
+wordpress.key
+wordpress.crt

--- a/javier-carnero/exercise/README.md
+++ b/javier-carnero/exercise/README.md
@@ -2,7 +2,9 @@
 
 Kubernetes training exercise deploying two wordpress connected to mariadb.
 
-With *minikube* started, do `./command.bash` to start the app.
+With *minikube* started, do `./command.bash` to start the app. Finally access to https://wordpress.exercise.com
+
+*NOTE:* Some liveness/readiness probes have been disabled because aparently they don't behaviour as expected under minikube. 
 
 ## Excercise original description:
 

--- a/javier-carnero/exercise/README.md
+++ b/javier-carnero/exercise/README.md
@@ -1,6 +1,8 @@
 # Kubernetes Bitnami Intro Training Exercise
 
-Work to be done.
+Kubernetes training exercise deploying two wordpress connected to mariadb.
+
+With *minikube* started, do `./command.bash` to start the app.
 
 ## Excercise original description:
 

--- a/javier-carnero/exercise/README.md
+++ b/javier-carnero/exercise/README.md
@@ -1,0 +1,60 @@
+# Kubernetes Bitnami Intro Training Exercise
+
+Work to be done.
+
+## Excercise original description:
+
+### WP + MariaDB
+
+Create the K8s resources you need to deploy a WP site on your cluster using MariaDB as database with the characteristics below:
+
+* All the resources should be created under the *exercise* namespace.
+* The WP site should use a MariaDB database.
+* Use ConfigMaps and Secrets to configure both MariaDB and WP.
+  * Admin user for WP should be "kubernetes" with password "training"
+  * MariaDB password should NOT be empty
+* WP should be accessible through http using a NGINX Ingress on the URL *wordpress.exercise.com*.
+
+Bonus:
+
+* Add appropriate readiness/liveness probes to MariaDB and WP containers.
+* WP should be accessible through http/https using a NGINX Ingress on the URL *wordpress.exercise.com* . Ingress should handle the TLS certificates.
+
+### What to deliver
+
+* YAML/JSON files with the definitions of every requested K8s object. Templates are provided.
+* If you created your resources from the command line, attach a bash script with the commands used to create them. Sth like:
+
+```
+#!/bin/bash
+
+kubectl create secret generic ...
+```
+
+Use the structure below on your PR To GitHub (https://github.com/bitnami-labs/k8s-intro-training):
+
+```
+|
+|-/<your-name>
+|-/<your-name>/exercise/
+|-/<your-name>/exercise/README.md
+|-/<your-name>/exercise/commands.bash
+|-/<your-name>/exercise/*.yaml
+```
+
+### Tips
+
+* Use a linter to avoid syntax errors on your YAML/JSON files
+* You can user the Docker Image below to run a linter
+
+```
+docker run -v /path-to-your-defs:/opt/data-definitions \
+juanariza131/linter:latest
+```
+
+* You can use the command below in order to create your TLS certificates:
+
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/CN=wordpress.exercise.com" -keyout wordpress.key -out wordpress.crt  
+```
+

--- a/javier-carnero/exercise/cm.yaml
+++ b/javier-carnero/exercise/cm.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # name: XXXX
+  # namespace: XXXX
+data:
+  # key: value
+  # ...

--- a/javier-carnero/exercise/cm.yaml
+++ b/javier-carnero/exercise/cm.yaml
@@ -1,8 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  # name: XXXX
-  # namespace: XXXX
+  name: training
+  namespace: exercise
 data:
-  # key: value
-  # ...
+  mariadb_host: mariadb
+  wp_db_name: wordpress
+  wp_db_user: wordpress
+  wp_user: kubernetes
+  
+  

--- a/javier-carnero/exercise/commands.bash
+++ b/javier-carnero/exercise/commands.bash
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 kubectl create namespace exercise
 
 kubectl create -f cm.yaml
@@ -13,5 +15,7 @@ kubectl create -f wordpress-deployment.yaml
 kubectl create -f wordpress-svc.yaml
 
 minikube addons enable ingress
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/CN=wordpress.exercise.com" -keyout wordpress.key -out wordpress.crt
+kubectl create secret tls sslcerts --namespace="exercise" --key wordpress.key --cert wordpress.crt
 kubectl create -f ingress.yaml
 echo "$(minikube ip)   wordpress.exercise.com" | sudo tee -a /etc/hosts

--- a/javier-carnero/exercise/commands.bash
+++ b/javier-carnero/exercise/commands.bash
@@ -1,0 +1,1 @@
+echo "TO BE DONE"

--- a/javier-carnero/exercise/commands.bash
+++ b/javier-carnero/exercise/commands.bash
@@ -1,1 +1,17 @@
-echo "TO BE DONE"
+kubectl create namespace exercise
+
+kubectl create -f cm.yaml
+
+kubectl create secret generic mariadb --namespace="exercise" --from-literal=password=mariapower
+kubectl create secret generic wordpressdb --namespace="exercise" --from-literal=password=wordpresspower
+kubectl create secret generic wordpress --namespace="exercise" --from-literal=password=training
+
+kubectl create -f mariadb-deployment.yaml
+kubectl create -f mariadb-svc.yaml
+
+kubectl create -f wordpress-deployment.yaml
+kubectl create -f wordpress-svc.yaml
+
+#minikube addons enable ingress
+kubectl create -f ingress.yaml
+echo "$(minikube ip)   wordpress.exercise.com" | sudo tee -a /etc/hosts

--- a/javier-carnero/exercise/commands.bash
+++ b/javier-carnero/exercise/commands.bash
@@ -12,6 +12,6 @@ kubectl create -f mariadb-svc.yaml
 kubectl create -f wordpress-deployment.yaml
 kubectl create -f wordpress-svc.yaml
 
-#minikube addons enable ingress
+minikube addons enable ingress
 kubectl create -f ingress.yaml
 echo "$(minikube ip)   wordpress.exercise.com" | sudo tee -a /etc/hosts

--- a/javier-carnero/exercise/ingress.yaml
+++ b/javier-carnero/exercise/ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  # name: XXXX
+  # namespace: XXXX
+spec:
+  # rules: XXXX
+  # ...

--- a/javier-carnero/exercise/ingress.yaml
+++ b/javier-carnero/exercise/ingress.yaml
@@ -1,8 +1,17 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  # name: XXXX
-  # namespace: XXXX
+  name: ingress
+  namespace: exercise
+  annotations:
+    nginx.ingress.kubernetes.io/affinity: cookie
+    service-upstream: "true"
 spec:
-  # rules: XXXX
-  # ...
+  rules:
+    - host: wordpress.exercise.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: wordpress
+              servicePort: 80

--- a/javier-carnero/exercise/ingress.yaml
+++ b/javier-carnero/exercise/ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     nginx.ingress.kubernetes.io/affinity: cookie
     service-upstream: "true"
 spec:
+  tls:
+    - hosts:
+        - wordpress.exercise.com
+      secretName: sslcerts
   rules:
     - host: wordpress.exercise.com
       http:

--- a/javier-carnero/exercise/mariadb-deployment.yaml
+++ b/javier-carnero/exercise/mariadb-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  # name: XXXX
+  # namespace: XXXX
+spec:
+  # replicas: XXXX
+  template:
+    # metadata: XXXX
+    spec:
+      containers:
+      - image: bitnami/mariadb:latest
+        # name: XXXX
+        # env: XXXX
+        # ports: XXXX
+        # XXXX
+        # ...

--- a/javier-carnero/exercise/mariadb-deployment.yaml
+++ b/javier-carnero/exercise/mariadb-deployment.yaml
@@ -26,3 +26,11 @@ spec:
               secretKeyRef:
                 name: mariadb
                 key: password
+        livenessProbe:
+          tcpSocket:
+            port: 3306
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
+          initialDelaySeconds: 5
+          periodSeconds: 3

--- a/javier-carnero/exercise/mariadb-deployment.yaml
+++ b/javier-carnero/exercise/mariadb-deployment.yaml
@@ -1,17 +1,28 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  # name: XXXX
-  # namespace: XXXX
+  name: mariadb
+  namespace: exercise
+  labels:
+    app: mariadb
+    type: exercise
 spec:
-  # replicas: XXXX
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+  replicas: 1
   template:
-    # metadata: XXXX
+    metadata:
+      labels:
+        app: mariadb
+        type: exercise
     spec:
       containers:
       - image: bitnami/mariadb:latest
-        # name: XXXX
-        # env: XXXX
-        # ports: XXXX
-        # XXXX
-        # ...
+        name: mariadb
+        env:
+          - name: MARIADB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mariadb
+                key: password

--- a/javier-carnero/exercise/mariadb-svc.yaml
+++ b/javier-carnero/exercise/mariadb-svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  # name: XXXX
+  # namespace: XXXX
+spec:
+  # type: XXXX
+  # ports: XXXX
+  # selector: XXXX
+  # ...

--- a/javier-carnero/exercise/mariadb-svc.yaml
+++ b/javier-carnero/exercise/mariadb-svc.yaml
@@ -1,10 +1,13 @@
-apiVersion: "v1"
-kind: "Service"
+apiVersion: v1
+kind: Service
 metadata:
-  # name: XXXX
-  # namespace: XXXX
+  name: mariadb
+  namespace: exercise
 spec:
-  # type: XXXX
-  # ports: XXXX
-  # selector: XXXX
-  # ...
+  type: ClusterIP
+  ports:
+    - name: data
+      port: 3306
+      targetPort: 3306
+  selector:
+    app: mariadb

--- a/javier-carnero/exercise/wordpress-deployment.yaml
+++ b/javier-carnero/exercise/wordpress-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  # name: XXXX
+  # namespace: XXXX
+spec:
+  # replicas: XXXX
+  template:
+    # metadata: XXXX
+    spec:
+      containers:
+      - image: bitnami/wordpress:latest
+        # name: XXXX
+        # env: XXXX
+        # ports: XXXX
+        # XXXX
+        # ...

--- a/javier-carnero/exercise/wordpress-deployment.yaml
+++ b/javier-carnero/exercise/wordpress-deployment.yaml
@@ -71,3 +71,11 @@ spec:
               secretKeyRef:
                 name: wordpress
                 key: password
+        # livenessProbe:
+        #   httpGet:
+        #     path: /wp-login.php
+        #     port: http
+        # readinessProbe:
+        #   httpGet:
+        #     path: /wp-login.php
+        #     port: http

--- a/javier-carnero/exercise/wordpress-deployment.yaml
+++ b/javier-carnero/exercise/wordpress-deployment.yaml
@@ -1,17 +1,73 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  # name: XXXX
-  # namespace: XXXX
+  name: wordpress
+  namespace: exercise
+  labels:
+    app: wordpress
+    type: exercise
 spec:
-  # replicas: XXXX
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+  replicas: 2
   template:
-    # metadata: XXXX
+    metadata:
+      labels:
+        app: wordpress
+        type: exercise
     spec:
       containers:
       - image: bitnami/wordpress:latest
-        # name: XXXX
-        # env: XXXX
-        # ports: XXXX
-        # XXXX
-        # ...
+        name: wordpress
+        env:
+          - name: MARIA_DB_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: training
+                key: mariadb_host
+          - name: MARIADB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mariadb
+                key: password
+          - name: MYSQL_CLIENT_CREATE_DATABASE_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: training
+                key: wp_db_name
+          - name: MYSQL_CLIENT_CREATE_DATABASE_USER
+            valueFrom:
+              configMapKeyRef:
+                name: training
+                key: wp_db_user
+          - name: MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: wordpressdb
+                key: password
+          - name: WORDPRESS_DATABASE_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: training
+                key: wp_db_name
+          - name: WORDPRESS_DATABASE_USER
+            valueFrom:
+              configMapKeyRef:
+                name: training
+                key: wp_db_user
+          - name: WORDPRESS_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: wordpressdb
+                key: password
+          - name: WORDPRESS_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: training
+                key: wp_user
+          - name: WORDPRESS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: wordpress
+                key: password

--- a/javier-carnero/exercise/wordpress-svc.yaml
+++ b/javier-carnero/exercise/wordpress-svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  # name: XXXX
+  # namespace: XXXX
+spec:
+  # type: XXXX
+  # ports: XXXX
+  # selector: XXXX
+  # ...

--- a/javier-carnero/exercise/wordpress-svc.yaml
+++ b/javier-carnero/exercise/wordpress-svc.yaml
@@ -1,10 +1,16 @@
-apiVersion: "v1"
-kind: "Service"
+apiVersion: v1
+kind: Service
 metadata:
-  # name: XXXX
-  # namespace: XXXX
+  name: wordpress
+  namespace: exercise
 spec:
-  # type: XXXX
-  # ports: XXXX
-  # selector: XXXX
-  # ...
+  type: ClusterIP
+  ports:
+    - name: frontend
+      port: 80
+      targetPort: 80
+    - name: frontend-ssl
+      port: 443
+      targetPort: 443
+  selector:
+    app: wordpress


### PR DESCRIPTION
Solution with liveness/readiness probes and HTTPs enabled.

Wordpress probes are disabled (commented) because they provoke a 503 temporary failure on the app. In the same way, MariaDB liveness probe has been changed from an exec type to a socket type, as the previous one would eventually fail. I presume both cases are related with minikube lack of resources, but I'm not sure.